### PR TITLE
ineteractive marker: add missing publishing of interactive marker

### DIFF
--- a/humanoid_league_interactive_marker/package.xml
+++ b/humanoid_league_interactive_marker/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>humanoid_league_interactive_marker</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>The humanoid_league_interactive_marker package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>


### PR DESCRIPTION
Previously only the goal relative was published, but since the behavior is listening to the goal parts, I added publishing of them

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

