### PR TITLE
interactive_markers: transparency and remove required tag from rviz node

### DIFF
--- a/humanoid_league_interactive_marker/launch/interactive_marker.launch
+++ b/humanoid_league_interactive_marker/launch/interactive_marker.launch
@@ -1,7 +1,7 @@
 <launch>
     <rosparam file="$(find humanoid_league_interactive_marker)/config/camera_info.yaml" command="load"/>
 
-    <node name="rviz" pkg="rviz" type="rviz" output="screen" required="true"
+    <node name="rviz" pkg="rviz" type="rviz" output="screen" 
           args="-d $(find humanoid_league_interactive_marker)/config/interactive_marker.rviz">
     </node>
     <node name="interactive_marker" pkg="humanoid_league_interactive_marker" type="interactive_marker.py" output="screen"/>

--- a/humanoid_league_interactive_marker/package.xml
+++ b/humanoid_league_interactive_marker/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>humanoid_league_interactive_marker</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>The humanoid_league_interactive_marker package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/humanoid_league_interactive_marker/src/rviz_behavior_test/interactive_marker.py
+++ b/humanoid_league_interactive_marker/src/rviz_behavior_test/interactive_marker.py
@@ -134,7 +134,7 @@ class BallMarker(RobocupInteractiveMarker):
         marker.color.r = 1.0
         marker.color.g = 0.0
         marker.color.b = 0.0
-        marker.color.a = 1.0
+        marker.color.a = 0.4
 
         return (marker,)
 
@@ -205,7 +205,7 @@ class GoalMarker(RobocupInteractiveMarker):
         lpost.color.r = 1.0
         lpost.color.g = 1.0
         lpost.color.b = 1.0
-        lpost.color.a = 1.0
+        lpost.color.a = 0.4
         lpost.pose.position = Point(0, GOAL_WIDTH / 2, GOAL_HEIGHT / 2)
 
         rpost = Marker()
@@ -214,7 +214,7 @@ class GoalMarker(RobocupInteractiveMarker):
         rpost.color.r = 1.0
         rpost.color.g = 1.0
         rpost.color.b = 1.0
-        rpost.color.a = 1.0
+        rpost.color.a = 0.4
         rpost.pose.position = Point(0, - GOAL_WIDTH / 2, GOAL_HEIGHT / 2)
 
         bar = Marker()
@@ -223,7 +223,7 @@ class GoalMarker(RobocupInteractiveMarker):
         bar.color.r = 1.0
         bar.color.g = 1.0
         bar.color.b = 1.0
-        bar.color.a = 1.0
+        bar.color.a = 0.4
         bar.pose.position = Point(0, 0, GOAL_HEIGHT)
         bar.pose.orientation = Quaternion(math.sqrt(2) / 2, 0, 0, math.sqrt(2) / 2)
 
@@ -400,7 +400,7 @@ class ObstacleMarker(RobocupInteractiveMarker):
         marker.color.r = 0.0
         marker.color.g = 0.0
         marker.color.b = 0.0
-        marker.color.a = 1.0
+        marker.color.a = 0.4
         marker.pose.position = Point(0, 0, OBSTACLE_HEIGT / 2)
 
         return (marker,)


### PR DESCRIPTION
## Proposed changes
make interactive markers partly transparent so underlying objects can be visualized


## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- ~[ ] Write documentation~
- ~[ ] Create issues for future work~
- [x] Test on your machine
- ~[ ] Test on the robot~
- [x] Put the PR on our Project board

