### PR TITLE
RViZ interactive marker config: added world model objects marker

### DIFF
--- a/humanoid_league_interactive_marker/config/interactive_marker.rviz
+++ b/humanoid_league_interactive_marker/config/interactive_marker.rviz
@@ -63,6 +63,11 @@ Visualization Manager:
       Show Visual Aids: false
       Update Topic: /basic_controls/update
       Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /visualization_world_model_markers
+      Name: WorldModelMarker
+      Queue Size: 100
     - Alpha: 1
       Class: rviz/RobotModel
       Collision Enabled: false

--- a/humanoid_league_interactive_marker/package.xml
+++ b/humanoid_league_interactive_marker/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>humanoid_league_interactive_marker</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>The humanoid_league_interactive_marker package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
The Marker for the world model objects is added to the RViZ config. Therefore, they are directly shown in the RViZ Behavior test (if the behavior is running) without having to manually add the marker in RViZ.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
No related issue
## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

