### PR TITLE
Add CI config and rdmanifest files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
+
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("humanoid_league_gazebo_world")))
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("humanoid_league_interactive_marker")).withoutDocumentation().withoutPublishing())
+pipeline.execute()

--- a/humanoid_league_gazebo_world/.rdmanifest
+++ b/humanoid_league_gazebo_world/.rdmanifest
@@ -1,0 +1,17 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/humanoid_league_gazebo_world'
+depends:
+- gazebo_ros
+- urdf
+- gazebo_ros_control
+- effort_controllers
+- joint_state_controller
+- bitbots_docs
+exec-path: humanoid_league_visualization-master/humanoid_league_gazebo_world
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/humanoid_league_gazebo_world'
+uri: https://github.com/bit-bots/humanoid_league_visualization/archive/refs/heads/master.tar.gz

--- a/humanoid_league_interactive_marker/.rdmanifest
+++ b/humanoid_league_interactive_marker/.rdmanifest
@@ -1,0 +1,11 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/humanoid_league_interactive_marker'
+depends: []
+exec-path: humanoid_league_visualization-master/humanoid_league_interactive_marker
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/humanoid_league_interactive_marker'
+uri: https://github.com/bit-bots/humanoid_league_visualization/archive/refs/heads/master.tar.gz


### PR DESCRIPTION
## Proposed changes
This change adds `.rdmanifest` files for *gazebo_world* and *interactive_marker* so that they can be installed via rosdep in CI.
It also adds CI configuration to build these packages automatically.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

